### PR TITLE
feat: display notary name in the hero heading of the GA form

### DIFF
--- a/packages/fe/content/pages/apply-general.json
+++ b/packages/fe/content/pages/apply-general.json
@@ -12,8 +12,7 @@
   "page_content": {
     "hero": {
       "label": "General Application",
-      "heading": "Fill out an application to send to the following notary → <span class='highlight'>|notary|</span>"
-
+      "heading": "Send an application for DataCap to the notary you selected<br /><span class='highlight'>|notary|</span>"
     },
     "back_button": {
       "type": "nuxt-link",

--- a/packages/fe/pages/apply/general/notaries/_name.vue
+++ b/packages/fe/pages/apply/general/notaries/_name.vue
@@ -268,6 +268,13 @@ export default {
   overflow: hidden;
 }
 
+:deep(#hero) {
+  .highlight {
+    display: block;
+    margin-top: 0.5rem;
+  }
+}
+
 #application {
   position: relative;
   padding: 8.75rem 0;


### PR DESCRIPTION
Notary name is now displayed in the Hero of the GA form:

<img width="651" alt="Screenshot 2023-03-14 at 6 37 05 PM" src="https://user-images.githubusercontent.com/11708190/225157566-45c71bd2-7890-483a-93d3-6c4491a00e45.png">
