### PR TITLE
feat: added `application_data_type` field to LDA

### DIFF
--- a/packages/be/static/large-application-template.md
+++ b/packages/be/static/large-application-template.md
@@ -22,6 +22,9 @@ weekly_data_size weekly_data_size_unit
 ### On-chain address for first allocation
 filecoin_address
 
+### Data Type of Application
+application_data_type
+
 ### Custom multisig
 custom_multisig
 

--- a/packages/fe/content/pages/apply-large.json
+++ b/packages/fe/content/pages/apply-large.json
@@ -267,6 +267,25 @@
           },
           "defaultValue": ""
         },
+        "application_data_type": {
+          "type": "select",
+          "modelKey": "application_data_type",
+          "label": "Data Type of Application",
+          "description": "Where is the data in this dataset sourced from?",
+          "required": true,
+          "output": "option",
+          "validationMessage": {
+            "required": "This field is required"
+          },
+          "options": [
+            { "label": "Slingshot" },
+            { "label": "Public, Open Dataset (Research/Non-Profit)" },
+            { "label": "Public, Open Commercial/Enterprise" },
+            { "label": "Private Commercial/Enterprise" },
+            { "label": "Private Non-Profit / Social impact" }
+          ],
+          "defaultValue": ""
+        },
         "custom_multisig": {
           "type": "checkbox",
           "modelKey": "custom_multisig",

--- a/packages/fe/pages/apply/large.vue
+++ b/packages/fe/pages/apply/large.vue
@@ -113,6 +113,11 @@
             form-id="filplus_application" />
 
           <FieldContainer
+            :scaffold="formScaffold.application_data_type"
+            field-key="application_data_type"
+            form-id="filplus_application" />
+
+          <FieldContainer
             :scaffold="formScaffold.identifier"
             field-key="identifier"
             form-id="filplus_application" />


### PR DESCRIPTION
Added the following new field to the LDA:

```yml
- type: dropdown
  attributes:
    label: Data Type of Application
    options:    
      - Slingshot
      - Public, Open Dataset (Research/Non-Profit)
      - Public, Open Commercial/Enterprise
      - Private Commercial/Enterprise
      - Private Non-Profit / Social impact
```

Related PR → [https://github.com/filecoin-project/filecoin-plus-large-datasets/pull/1795](https://github.com/filecoin-project/filecoin-plus-large-datasets/pull/1795)

Example of a successful test submission → [https://github.com/data-preservation-programs/filecoin-plus-large-datasets/issues/31](https://github.com/data-preservation-programs/filecoin-plus-large-datasets/issues/31)