### PR TITLE
feat: GA auto-selects notary from URL

### DIFF
--- a/packages/fe/modules/form/plugins/field.js
+++ b/packages/fe/modules/form/plugins/field.js
@@ -223,6 +223,20 @@ const Field = (app, store, id) => {
       if (!field) {
         const form = app.$form(formId).get()
         const value = getValue(app, scaffold, form, formId, false, groupIndex)
+        console.log({
+          id,
+          fieldKey,
+          formId,
+          ...(typeof groupIndex === 'number' && { groupIndex }),
+          value,
+          includeInFormSubmission: true, // used to keep "validate" disabled in field-standalone component
+          originalValue: value,
+          state: 'valid',
+          validate: true,
+          validation: false,
+          resetTo,
+          scaffold
+        })
         await store.dispatch('form/setField', {
           id,
           fieldKey,

--- a/packages/fe/pages/apply/general/notaries/_name.vue
+++ b/packages/fe/pages/apply/general/notaries/_name.vue
@@ -131,6 +131,7 @@ import AuthButton from '@/components/auth-button'
 import Chevron from '@/components/icons/chevron'
 
 import ApplyGeneralPageData from '@/content/pages/apply-general.json'
+import NotariesPageData from '@/content/pages/notaries.json'
 
 // ====================================================================== Export
 export default {
@@ -157,10 +158,21 @@ export default {
     const name = params.name
     const notariesList = await store.dispatch('general/getCachedFile', 'notaries-list.json')
     const notary = notariesList.find(notary => notary.name === name || notary.organization === name)
-    const notaryField = app.$field('notary|filplus_application').get()
-    if (!notary || !notaryField) { return redirect('/apply/general/notaries') }
-    await store.dispatch('general/getBaseData', { key: 'apply-general', data: ApplyGeneralPageData })
+    if (!notary) { return redirect('/apply/general/notaries') }
+    const notaryFieldId = 'notary|filplus_application'
+    const notaryField = app.$field(notaryFieldId).get()
     await app.$form('filplus_application').register(store.getters['general/application'])
+    if (!notaryField) {
+      await app.$field(notaryFieldId).register(
+        'filplus_application',
+        false,
+        'notary',
+        NotariesPageData.page_content.form.scaffold.notary,
+        'nullState'
+      )
+      await app.$field(notaryFieldId).updateValue(name)
+    }
+    await store.dispatch('general/getBaseData', { key: 'apply-general', data: ApplyGeneralPageData })
   },
 
   head () {


### PR DESCRIPTION
Previous behaviour redirected the user to the notary selection table if landing on GA via SSR, even if notary was selected in the URL. Now, if the notary is selected in the URL and also the notary does exist in the list, then it is simply auto-selected in the form and the user is not redirected.