### PR TITLE
feat: new fields for Hubspot submission + updating contact

### DIFF
--- a/packages/be/liftoff.js
+++ b/packages/be/liftoff.js
@@ -56,6 +56,7 @@ try {
 //     const user = await MC.model.User.findOne({ githubUsername: 'timelytree' })
 //     console.log(user)
 //     // user.hubspotOptIn = false
+//     // user.hubspotOptInContactId = undefined
 //     // user.hubspotOptInEmail = undefined
 //     // user.hubspotOptInFirstName = undefined
 //     // user.hubspotOptInLastName = undefined

--- a/packages/be/modules/application/logic/submit-hubspot-contact.js
+++ b/packages/be/modules/application/logic/submit-hubspot-contact.js
@@ -29,26 +29,64 @@ const submitContact = async (payload) => {
   }
 }
 
+// /////////////////////////////////////////////////////////////// updateContact
+const updateContact = async (hubspotOptInContactId, properties) => {
+  try {
+    const options = { headers: { 'content-type': 'application/json', authorization: `Bearer ${process.env.HUBSPOT_TOKEN}` } }
+    const response = await Axios.patch(`https://api.hubapi.com/crm/v3/objects/contacts/${hubspotOptInContactId}`, {
+      properties
+    }, options)
+    return response.data
+  } catch (e) {
+    console.log('=================================== [Function: updateContact]')
+    const response = e.response
+    console.log(response && response.data ? response.data : e)
+    throw e
+  }
+}
+
 // ////////////////////////////////////////////////////////////////////// Export
 // -----------------------------------------------------------------------------
 module.exports = async (res, user, payload) => {
   try {
-    const submission = await submitContact(payload)
-    const hubspotContactId = submission.id
-    if (MC.serverFlag !== 'production') {
-      console.log(`✉️  Hubspot contact ${payload.email}|${user._id} submitted with Contact ID → ${hubspotContactId}`)
+    let hubspotOptInContactId = user.hubspotOptInContactId
+    let message, userToUpdate
+    if (!hubspotOptInContactId) { // if no id, then submit a new contact
+      const submission = await submitContact(payload)
+      hubspotOptInContactId = submission.id
+      message = `✉️  [New] Hubspot contact ${payload.email}|${user._id} submitted with Contact ID → ${hubspotOptInContactId}`
+      userToUpdate = {
+        _id: user._id,
+        hubspotOptIn: true,
+        hubspotOptInContactId,
+        hubspotOptInFirstName: payload.firstname,
+        hubspotOptInLastName: payload.lastname,
+        hubspotOptInEmail: payload.email,
+        hubspotOptInApplicationCompanyName: payload.company,
+        hubspotOptInApplicationRegion: payload.fil__application_region,
+        hubspotOptInApplicationDatacapRequested: payload.fil__application_datacap_requested,
+        hubspotOptInApplicationWalletAddress: payload.filecoin_wallet_address
+      }
+    } else { // otherwise, update the existing contact
+      await updateContact(hubspotOptInContactId, {
+        company: payload.company,
+        ...(payload.fil__application_region && { fil__application_region: payload.fil__application_region }), // fil__application_region: payload.fil__application_region,
+        fil__application_datacap_requested: payload.fil__application_datacap_requested,
+        filecoin_wallet_address: payload.filecoin_wallet_address
+      })
+      userToUpdate = {
+        _id: user._id,
+        hubspotOptInApplicationCompanyName: payload.company,
+        hubspotOptInApplicationRegion: payload.fil__application_region,
+        hubspotOptInApplicationDatacapRequested: payload.fil__application_datacap_requested,
+        hubspotOptInApplicationWalletAddress: payload.filecoin_wallet_address
+      }
+      message = `✉️  [Update] Hubspot contact ${hubspotOptInContactId}|${user._id} updated`
     }
-    await UpdateUser({
-      _id: user._id,
-      hubspotOptIn: true,
-      hubspotOptInFirstName: payload.firstname,
-      hubspotOptInLastName: payload.lastname,
-      hubspotOptInEmail: payload.email,
-      hubspotOptInApplicationCompanyName: payload.company,
-      hubspotOptInApplicationRegion: payload.fil__application_region,
-      hubspotOptInApplicationDatacapRequested: payload.fil__application_datacap_requested,
-      hubspotOptInApplicationWalletAddress: payload.filecoin_wallet_address
-    })
+    await UpdateUser(userToUpdate)
+    if (MC.serverFlag !== 'production') {
+      console.log(message)
+    }
   } catch (e) {
     console.log('============================ [Function: submitHubspotContact]')
     throw e

--- a/packages/be/modules/application/rest/submit-application.js
+++ b/packages/be/modules/application/rest/submit-application.js
@@ -74,7 +74,7 @@ MC.app.post('/submit-application', async (req, res) => {
       console.log(template)
     }
     const hubspotOptIn = application.hubspot_opt_in
-    if (!user.hubspotOptIn && hubspotOptIn) {
+    if ((!user.hubspotOptIn && hubspotOptIn) || user.hubspotOptInContactId) {
       await SubmitHubspotContact(res, user, {
         email: application.hubspot_opt_in_email,
         firstname: application.hubspot_opt_in_first_name,

--- a/packages/be/modules/user/model/index.js
+++ b/packages/be/modules/user/model/index.js
@@ -38,6 +38,11 @@ const UserSchema = new Schema({
     required: false,
     default: false
   },
+  hubspotOptInContactId: {
+    type: String,
+    required: false,
+    default: null
+  },
   hubspotOptInFirstName: {
     type: String,
     required: false,

--- a/packages/fe/store/account.js
+++ b/packages/fe/store/account.js
@@ -92,7 +92,7 @@ const actions = {
         message: 'Application submitted successfully'
       })
       this.$gtm.push({ event: `success_${tag}` })
-      // this.$router.push('/apply/success')
+      this.$router.push('/apply/success')
     } catch (e) {
       console.log('================= [Store Action: account/submitApplication]')
       console.log(e)


### PR DESCRIPTION
New fields have been added to the Hubspot submission:

- `company`
- `fil__application_region`
- `fil__application_datacap_requested`
- `filecoin_wallet_address`

As well, in **non-production** environments, the `hubspot_owner_id` points to @orvn's user in the Hubspot db and adds an `hs_lead_status: 'Disqualified'` field as well.

Subsequent application submissions lead to a PATCH rather than a POST → the following fields are _updated_:

- `company`
- `fil__application_region`
- `fil__application_datacap_requested`
- `filecoin_wallet_address`