### PR TITLE
chore: update to new GTM id

### DIFF
--- a/packages/fe/nuxt.config.js
+++ b/packages/fe/nuxt.config.js
@@ -124,7 +124,7 @@ export default {
   gtm: {
     enabled: env === 'production', // disable in all but production
     // Currently hardcoded, can be added as an environment variable instead
-    id: 'GTM-N7WMPKK',
+    id: 'GTM-MNFJ3D4',
     pageTracking: true
   },
   // ///////////////////////////////////////////////////////////// [Module] Auth


### PR DESCRIPTION
Updates the GTM instance to a new ID. All tags and triggers are imported in the new instance.