### PR TITLE
fix: label on history page

### DIFF
--- a/packages/fe/components/auth-button.vue
+++ b/packages/fe/components/auth-button.vue
@@ -91,7 +91,7 @@ export default {
       return {
         type: 'nuxt-link',
         href: `/account/${this.account.githubUsername}/applications`,
-        label: 'Application History Page'
+        label: 'Application History'
       }
     }
   }


### PR DESCRIPTION
Changes the page label to just say `Application History`. 

@timelytree I think one of the reasons the nav bar was having issues was this long page name in the dropdown, which in turn affected the width in the dropdown component.