### PR TITLE
feat: native gtm module

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4144,109 +4144,6 @@
       "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.1.tgz",
       "integrity": "sha512-aA964RUCsBt0FGoNIlA3uFgo2hO+WWC0fiC6DBps/0SFzkKcYoM/3CzVLIa5xSsrFjdioMdYgAIbwo80qp2MoA=="
     },
-    "node_modules/@nuxtjs/gtm": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@nuxtjs/gtm/-/gtm-2.4.0.tgz",
-      "integrity": "sha512-Of5KuBBFwRjyJ6AuRrIQsh8J6ksIN2UegJDE8nBiTAanbwQBsAJ0hZibV9SjhKdGvGvWpbShQ4yR2bmQgY6XKA==",
-      "dependencies": {
-        "chalk": "^4.1.0",
-        "semver": "^7.3.2"
-      }
-    },
-    "node_modules/@nuxtjs/gtm/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/@nuxtjs/gtm/node_modules/chalk": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/@nuxtjs/gtm/node_modules/color-convert": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/@nuxtjs/gtm/node_modules/color-name": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
-    },
-    "node_modules/@nuxtjs/gtm/node_modules/has-flag": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@nuxtjs/gtm/node_modules/lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@nuxtjs/gtm/node_modules/semver": {
-      "version": "7.3.8",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-      "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@nuxtjs/gtm/node_modules/supports-color": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@nuxtjs/gtm/node_modules/yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
-    },
     "node_modules/@nuxtjs/moment": {
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/@nuxtjs/moment/-/moment-1.6.1.tgz",
@@ -21810,7 +21707,6 @@
         "@nuxtjs/axios": "^5.13.6",
         "@nuxtjs/eslint-config": "^10.0.0",
         "@nuxtjs/eslint-module": "^3.0.2",
-        "@nuxtjs/gtm": "^2.4.0",
         "@nuxtjs/moment": "^1.6.1",
         "@nuxtjs/style-resources": "^1.2.1",
         "@tiptap/extension-character-count": "^2.0.0-beta.220",
@@ -25010,81 +24906,6 @@
           "version": "6.1.1",
           "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.1.tgz",
           "integrity": "sha512-aA964RUCsBt0FGoNIlA3uFgo2hO+WWC0fiC6DBps/0SFzkKcYoM/3CzVLIa5xSsrFjdioMdYgAIbwo80qp2MoA=="
-        }
-      }
-    },
-    "@nuxtjs/gtm": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@nuxtjs/gtm/-/gtm-2.4.0.tgz",
-      "integrity": "sha512-Of5KuBBFwRjyJ6AuRrIQsh8J6ksIN2UegJDE8nBiTAanbwQBsAJ0hZibV9SjhKdGvGvWpbShQ4yR2bmQgY6XKA==",
-      "requires": {
-        "chalk": "^4.1.0",
-        "semver": "^7.3.2"
-      },
-      "dependencies": {
-        "ansi-styles": {
-          "version": "4.3.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-          "requires": {
-            "color-convert": "^2.0.1"
-          }
-        },
-        "chalk": {
-          "version": "4.1.2",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-          "requires": {
-            "ansi-styles": "^4.1.0",
-            "supports-color": "^7.1.0"
-          }
-        },
-        "color-convert": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-          "requires": {
-            "color-name": "~1.1.4"
-          }
-        },
-        "color-name": {
-          "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
-        },
-        "has-flag": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
-        },
-        "lru-cache": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-          "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-          "requires": {
-            "yallist": "^4.0.0"
-          }
-        },
-        "semver": {
-          "version": "7.3.8",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-          "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
-          "requires": {
-            "lru-cache": "^6.0.0"
-          }
-        },
-        "supports-color": {
-          "version": "7.2.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-          "requires": {
-            "has-flag": "^4.0.0"
-          }
-        },
-        "yallist": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
         }
       }
     },
@@ -29647,7 +29468,6 @@
         "@nuxtjs/axios": "^5.13.6",
         "@nuxtjs/eslint-config": "^10.0.0",
         "@nuxtjs/eslint-module": "^3.0.2",
-        "@nuxtjs/gtm": "^2.4.0",
         "@nuxtjs/moment": "^1.6.1",
         "@nuxtjs/style-resources": "^1.2.1",
         "@tiptap/extension-character-count": "^2.0.0-beta.220",

--- a/packages/fe/modules/gtm/compatibility.js
+++ b/packages/fe/modules/gtm/compatibility.js
@@ -1,0 +1,19 @@
+const chalk = require('chalk')
+const semver = require('semver')
+
+function requireNuxtVersion (nuxt, version) {
+  const pkgName = require('../package.json').name
+  const currentVersion = semver.coerce(nuxt.constructor.version)
+  const requiredVersion = semver.coerce(version)
+
+  if (semver.lt(currentVersion, requiredVersion)) {
+    throw new Error(`\n
+      ${chalk.cyan(pkgName)} is not compatible with your current Nuxt version : ${chalk.yellow('v' + currentVersion)}\n
+      Required: ${chalk.green('v' + requiredVersion)} or ${chalk.cyan('higher')}
+    `)
+  }
+}
+
+module.exports = {
+  requireNuxtVersion
+}

--- a/packages/fe/modules/gtm/defaults.js
+++ b/packages/fe/modules/gtm/defaults.js
@@ -1,0 +1,25 @@
+const defaults = {
+  enabled: undefined,
+  debug: false,
+
+  id: undefined,
+  layer: 'dataLayer',
+  variables: {},
+
+  pageTracking: false,
+  pageViewEventName: 'nuxtRoute',
+
+  autoInit: true,
+  respectDoNotTrack: true,
+
+  scriptId: 'gtm-script',
+  scriptDefer: false,
+  scriptURL: 'https://www.googletagmanager.com/gtm.js',
+  crossOrigin: false,
+
+  noscript: true,
+  noscriptId: 'gtm-noscript',
+  noscriptURL: 'https://www.googletagmanager.com/ns.html'
+}
+
+module.exports = defaults

--- a/packages/fe/modules/gtm/module.js
+++ b/packages/fe/modules/gtm/module.js
@@ -1,0 +1,125 @@
+const path = require('path')
+const defaults = require('./defaults')
+const { requireNuxtVersion } = require('./compatibility')
+
+// doNotTrack polyfill
+// https://gist.github.com/pi0/a76fd97c4ea259c89f728a4a8ebca741
+const dnt = "(function(w,n,d,m,e,p){w[d]=(w[d]==1||n[d]=='yes'||n[d]==1||n[m]==1||(w[e]&&w[e][p]&&w[e][p]()))?1:0})(window,navigator,'doNotTrack','msDoNotTrack','external','msTrackingProtectionEnabled')"
+
+module.exports = async function gtmModule (_options) {
+  requireNuxtVersion(this.nuxt, '2.12.0')
+
+  const options = {
+    ...defaults,
+    ..._options,
+    ...this.options.gtm
+  }
+
+  // By default enable only for non development
+  if (options.enabled === undefined) {
+    options.enabled = !this.options.dev
+  }
+
+  if (options.dev !== undefined) {
+    // eslint-disable-next-line no-console
+    console.warn('[gtm] `dev` option is deprecated! Please use `enabled`')
+    if (options.dev === true && this.options.dev) {
+      options.enabled = true
+    }
+    delete options.dev
+  }
+
+  this.addTemplate({
+    src: path.resolve(__dirname, 'plugin.utils.js'),
+    fileName: 'gtm.utils.js',
+    options
+  })
+
+  if (!options.enabled) {
+    // Register mock plugin
+    this.addPlugin({
+      src: path.resolve(__dirname, 'plugin.mock.js'),
+      fileName: 'gtm.js',
+      options
+    })
+    return
+  }
+
+  // Async id evaluation
+  if (typeof (options.id) === 'function') {
+    options.id = await options.id()
+  }
+
+  // Build query
+  const query = {
+    // Default is dataLayer for google
+    l: options.layer !== 'dataLayer' ? options.layer : null,
+    ...options.variables
+  }
+  const queryString = Object.keys(query)
+    .filter(key => query[key] !== null && query[key] !== undefined)
+    .map(key => `${encodeURIComponent(key)}=${encodeURIComponent(query[key])}`)
+    .join('&')
+
+  // Compile scripts
+  const injectScript = `var f=d.getElementsByTagName(s)[0],j=d.createElement(s);${options.crossOrigin ? 'j.crossOrigin=\'' + options.crossOrigin + '\';' : ''}j.${options.scriptDefer ? 'defer' : 'async'}=true;j.src='${options.scriptURL + '?id=\'+i' + (queryString ? (`+'&${queryString}` + '\'') : '')};f.parentNode.insertBefore(j,f)` // deps: d,s,i
+
+  const doNotTrackScript = options.respectDoNotTrack ? 'if(w.doNotTrack||w[x][i])return;' : ''
+
+  const initLayer = "w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'})" // deps: w,l
+  let script = `w[x]={};w._gtm_inject=function(i){${doNotTrackScript}w[x][i]=1;${initLayer};${injectScript};}`
+
+  if (options.autoInit && options.id) {
+    script += `;w[y]('${options.id}')`
+  }
+
+  // Add doNotTrack polyfill and wrap to IIFE
+  script = `${dnt};(function(w,d,s,l,x,y){${script}})(window,document,'script','${options.layer}','_gtm_ids','_gtm_inject')`
+
+  // Guard against double IIFE executation in SPA mode (#3)
+  script = `if(!window._gtm_init){window._gtm_init=1;${script}}`
+
+  // Add google tag manager <script> to head
+  if (typeof this.options.head === 'function') {
+    // eslint-disable-next-line no-console
+    console.warn('[@nuxtjs/gtm] head is provided as a function which is not supported by this module at the moment. Removing user-provided head.')
+    this.options.head = {}
+  }
+  this.options.head.script = this.options.head.script || []
+  this.options.head.script.push({
+    hid: options.scriptId,
+    innerHTML: script
+  })
+
+  // Prepend google tag manager <noscript> fallback to <body>
+  const renderIframe = id => `<iframe src="${options.noscriptURL + '?id=' + id + '&' + queryString}" height="0" width="0" style="display:none;visibility:hidden" title="gtm"></iframe>`
+  if (options.noscript) {
+    this.options.head.noscript = this.options.head.noscript || []
+    this.options.head.noscript.push({
+      hid: options.noscriptId,
+      pbody: true,
+      innerHTML: options.id ? renderIframe(options.id) : '' /* placeholder for SSR calls */
+    })
+  }
+
+  // Disable sanitazions
+  this.options.head.__dangerouslyDisableSanitizersByTagID = this.options.head.__dangerouslyDisableSanitizersByTagID || {}
+  this.options.head.__dangerouslyDisableSanitizersByTagID[options.scriptId] = ['innerHTML']
+  this.options.head.__dangerouslyDisableSanitizersByTagID[options.noscriptId] = ['innerHTML']
+
+  // Remove trailing slash to avoid duplicate slashes when appending route path
+  const routerBase = this.options.router.base.replace(/\/+$/, '')
+
+  // Register plugin
+  this.addPlugin({
+    src: path.resolve(__dirname, 'plugin.js'),
+    fileName: 'gtm.js',
+    options: {
+      ...options,
+      renderIframe,
+      routerBase
+    }
+  })
+}
+
+module.exports.meta = require('../package.json')

--- a/packages/fe/modules/gtm/plugin.js
+++ b/packages/fe/modules/gtm/plugin.js
@@ -1,0 +1,93 @@
+import { log } from './gtm.utils'
+
+const _layer = '<%= options.layer %>'
+const _id = '<%= options.id %>'
+
+function gtmClient(ctx, initialized) {
+  return {
+    init(id = _id) {
+      if (initialized[id] || !window._gtm_inject) {
+        return
+      }
+      window._gtm_inject(id)
+      initialized[id] = true
+      log('init', id)
+    },
+    push(obj) {
+      if (!window[_layer]) {
+        window[_layer] = []
+      }
+      window[_layer].push(obj)
+      log('push', obj)
+    }
+  }
+}
+
+function gtmServer(ctx, initialized) {
+  const events = []
+  const inits = []
+
+  ctx.beforeNuxtRender(() => {
+    if (!inits.length && !events.length) {
+      return
+    }
+
+    const gtmScript = ctx.app.head.script.find(s => s.hid == '<%= options.scriptId %>')
+    gtmScript.innerHTML = `window['${_layer}']=${JSON.stringify(events)};${gtmScript.innerHTML}`
+
+    if (inits.length) {
+      gtmScript.innerHTML += `;${JSON.stringify(inits)}.forEach(function(i){window._gtm_inject(i)})`
+    }
+<% if (options.noscript) { %>
+    const gtmIframe = ctx.app.head.noscript.find(s => s.hid == '<%= options.noscriptId %>')
+    const renderIframe = id => `<%= options.renderIframe('${id}') %>`
+    if (inits.length) {
+      gtmIframe.innerHTML += inits.map(renderIframe)
+    }
+<% } %>
+  })
+
+  return {
+    init(id = _id) {
+      if (initialized[id]) {
+        return
+      }
+      inits.push(id)
+      initialized[id] = true
+      log('init', id)
+    },
+    push(obj) {
+      events.push(obj)
+      log('push', JSON.stringify(obj))
+    }
+  }
+}
+
+function startPageTracking(ctx) {
+  ctx.app.router.afterEach((to) => {
+    setTimeout(() => {
+      ctx.$gtm.push(to.gtm || {
+        routeName: to.name,
+        pageType: 'PageView',
+        pageUrl: '<%= options.routerBase %>' + to.fullPath,
+        pageTitle: (typeof document !== 'undefined' && document.title) || '',
+        event: '<%= options.pageViewEventName %>'
+      })
+    }, 250)
+  })
+}
+
+export default function (ctx, inject) {
+  const runtimeConfig = (ctx.$config && ctx.$config.gtm) || {}
+  const autoInit = <%= options.autoInit %>
+  const id = '<%= options.id %>'
+  const runtimeId = runtimeConfig.id
+  const initialized = autoInit && id ? {[id]: true} : {}
+  const $gtm = process.client ? gtmClient(ctx, initialized) : gtmServer(ctx, initialized)
+  if (autoInit && runtimeId && runtimeId !== id) {
+    $gtm.init(runtimeId)
+  }
+  ctx.$gtm = $gtm
+  inject('gtm', ctx.$gtm)
+  <% if (options.pageTracking) { %>if (process.client) { startPageTracking(ctx); }<% } %>
+}

--- a/packages/fe/modules/gtm/plugin.js
+++ b/packages/fe/modules/gtm/plugin.js
@@ -4,7 +4,14 @@ const _layer = '<%= options.layer %>'
 const _id = '<%= options.id %>'
 
 function gtmClient(ctx, initialized) {
-  let debounceWindow
+  let debounceTimer
+  const debounceDelay = 500 // Default debounce delay
+  
+  // Allowlist of events with low debounce time
+  // see https://support.google.com/analytics/answer/9234069?hl=en
+  const eventAllowList = [
+    "click", "file_download", "first_visit", "form_start", "form_submit", "page_view", "screen_view", "scroll", "session_start", "user_engagement", "video_complete", "video_progress", "video_start", "view_search_results"
+  ] 
   return {
     init(id = _id) {
       if (initialized[id] || !window._gtm_inject) {
@@ -18,14 +25,17 @@ function gtmClient(ctx, initialized) {
       if (!window[_layer]) {
         window[_layer] = []
       }
-      // Use debounce to prevent multiple calls in quick succession
-      if (debounceWindow) {
-        clearTimeout(debounceWindow)
+      const eventString = obj.event || ""
+
+      // Use a different debounce delay for allow-listed events
+      const delay = eventAllowList.includes(eventString) ? 50 : debounceDelay
+      if (debounceTimer) {
+        clearTimeout(debounceTimer)
       }
-      debounceWindow = setTimeout(() => {
+      debounceTimer = setTimeout(() => {
         window[_layer].push(obj)
         log('push', obj)
-      }, 500) // Debounce delay as timeout
+      }, delay)
     }
   }
 }

--- a/packages/fe/modules/gtm/plugin.js
+++ b/packages/fe/modules/gtm/plugin.js
@@ -4,6 +4,7 @@ const _layer = '<%= options.layer %>'
 const _id = '<%= options.id %>'
 
 function gtmClient(ctx, initialized) {
+  let debounceWindow
   return {
     init(id = _id) {
       if (initialized[id] || !window._gtm_inject) {
@@ -17,8 +18,14 @@ function gtmClient(ctx, initialized) {
       if (!window[_layer]) {
         window[_layer] = []
       }
-      window[_layer].push(obj)
-      log('push', obj)
+      // Use debounce to prevent multiple calls in quick succession
+      if (debounceWindow) {
+        clearTimeout(debounceWindow)
+      }
+      debounceWindow = setTimeout(() => {
+        window[_layer].push(obj)
+        log('push', obj)
+      }, 500) // Debounce delay as timeout
     }
   }
 }

--- a/packages/fe/modules/gtm/plugin.mock.js
+++ b/packages/fe/modules/gtm/plugin.mock.js
@@ -1,0 +1,39 @@
+// This is a mock version because gtm module is disabled
+// You can explicitly enable module using `gtm.enabled: true` in nuxt.config
+import { log } from './gtm.utils'
+
+const _layer = '<%= options.layer %>'
+const _id = '<%= options.id %>'
+
+function startPageTracking (ctx) {
+  ctx.app.router.afterEach((to) => {
+    setTimeout(() => {
+      ctx.$gtm.push(to.gtm || {
+        routeName: to.name,
+        pageType: 'PageView',
+        pageUrl: '<%= options.routerBase %>' + to.fullPath,
+        pageTitle: (typeof document !== 'undefined' && document.title) || '',
+        event: '<%= options.pageViewEventName %>'
+      })
+    }, 250)
+  })
+}
+
+export default function (ctx, inject) {
+  log('Using mocked API. Real GTM events will not be reported.')
+  const gtm = {
+    init: (id) => {
+      log('init', id)
+    },
+    push: (event) => {
+      log('push', process.client ? event : JSON.stringify(event))
+      if (typeof event.eventCallback === 'function') {
+        event.eventCallback()
+      }
+    }
+  }
+
+  ctx.$gtm = gtm
+  inject('gtm', gtm)
+  <% if (options.pageTracking) { %>if (process.client) { startPageTracking(ctx); }<% } %>
+}

--- a/packages/fe/modules/gtm/plugin.utils.js
+++ b/packages/fe/modules/gtm/plugin.utils.js
@@ -1,0 +1,6 @@
+const logSyle = 'background: #2E495E;border-radius: 0.5em;color: white;font-weight: bold;padding: 2px 0.5em;'
+
+export function log(...args) {
+  // eslint-disable-next-line no-console
+  <% if (options.debug) { %>console.log('%cGTM', logSyle, ...args)<% } %>
+}

--- a/packages/fe/nuxt.config.js
+++ b/packages/fe/nuxt.config.js
@@ -92,7 +92,6 @@ export default {
     '@nuxtjs/style-resources', // https://github.com/nuxt-community/style-resources-module/
     '@nuxtjs/axios', // https://axios.nuxtjs.org/
     'nuxt-socket-io', // https://nuxt-socket-io.netlify.app/
-    '@nuxtjs/gtm', // https://github.com/nuxt-community/gtm-module#nuxtjsgtm
     '~/modules/https',
     '~/modules/toaster',
     // '~/modules/slider',
@@ -101,7 +100,8 @@ export default {
     '~/modules/search',
     '~/modules/form',
     '~/modules/button',
-    '~/modules/ls'
+    '~/modules/ls',
+    '~/modules/gtm/module.js'
   ],
   // /////////////////////////////////// Plugins to load before mounting the App
   // ---------------------------------------------------------------------------

--- a/packages/fe/package.json
+++ b/packages/fe/package.json
@@ -17,7 +17,6 @@
     "@nuxtjs/axios": "^5.13.6",
     "@nuxtjs/eslint-config": "^10.0.0",
     "@nuxtjs/eslint-module": "^3.0.2",
-    "@nuxtjs/gtm": "^2.4.0",
     "@nuxtjs/moment": "^1.6.1",
     "@nuxtjs/style-resources": "^1.2.1",
     "@tiptap/extension-character-count": "^2.0.0-beta.220",


### PR DESCRIPTION
- Imports GTM module into this codebase
- Uninstalls external dependency
- Adds a timeout to debounce 500ms of GTM pushes so that only the last one comes through
- Adds an allow-list of events that only have a 50ms debounce, list taken from the [GA4 default events for web](https://support.google.com/analytics/answer/9234069?hl=en)

```js
["click", "file_download", "first_visit", "form_start", "form_submit", "page_view", "screen_view", "scroll", "session_start", "user_engagement", "video_complete", "video_progress", "video_start", "view_search_results"]
```