### PR TITLE
chore: bump app version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "filplus",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "filplus",
-      "version": "1.0.0",
+      "version": "2.0.0",
       "license": "Apache-2.0",
       "workspaces": [
         "packages/fe",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "filplus",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "description": "Fil+",
   "author": {
     "name": "Agency Undone",

--- a/packages/be/package.json
+++ b/packages/be/package.json
@@ -1,6 +1,6 @@
 {
   "name": "be",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "description": "Backend",
   "main": "app.js",
   "scripts": {

--- a/packages/fe/package.json
+++ b/packages/fe/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fe",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "description": "Frontend",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Bumps versioning to 2.0.0 for both `fe` and `be`, and the app as a whole.