### PR TITLE
feat: long github username styling

### DIFF
--- a/packages/fe/components/auth-button.vue
+++ b/packages/fe/components/auth-button.vue
@@ -20,7 +20,8 @@
           <div class="panel-left">
             <img :src="account.githubAvatarUrl" class="avatar" />
             <span class="username">
-              {{ account.githubUsername }}
+              <!-- {{ account.githubUsername }} -->
+              {{ username }}
             </span>
           </div>
           <IconChevron />
@@ -93,6 +94,9 @@ export default {
         href: `/account/${this.account.githubUsername}/applications`,
         label: 'Application History'
       }
+    },
+    username () {
+      return this.account.githubUsername + 'nnnnnnnnnnnnnnnnn'
     }
   }
 }
@@ -194,6 +198,7 @@ export default {
   display: flex;
   flex-direction: row;
   align-items: center;
+  margin-right: 1rem;
 }
 
 .avatar {
@@ -205,10 +210,9 @@ export default {
 }
 
 .username {
-  line-height: 1;
+  line-height: 1.2;
   font-weight: 500;
   color: $greenYellow;
-  margin-right: 1.5rem;
 }
 
 .icon-chevron {

--- a/packages/fe/components/auth-button.vue
+++ b/packages/fe/components/auth-button.vue
@@ -20,8 +20,7 @@
           <div class="panel-left">
             <img :src="account.githubAvatarUrl" class="avatar" />
             <span class="username">
-              <!-- {{ account.githubUsername }} -->
-              {{ username }}
+              {{ account.githubUsername }}
             </span>
           </div>
           <IconChevron />
@@ -94,10 +93,14 @@ export default {
         href: `/account/${this.account.githubUsername}/applications`,
         label: 'Application History'
       }
-    },
-    username () {
-      return this.account.githubUsername + 'nnnnnnnnnnnnnnnnn'
     }
+  },
+
+  mounted () {
+    this.$store.dispatch('auth/setAccount', {
+      ...this.account,
+      githubUsername: `${this.account.githubUsername}ausnsetuxiouicrgd`
+    })
   }
 }
 </script>

--- a/packages/fe/components/auth-button.vue
+++ b/packages/fe/components/auth-button.vue
@@ -94,13 +94,6 @@ export default {
         label: 'Application History'
       }
     }
-  },
-
-  mounted () {
-    this.$store.dispatch('auth/setAccount', {
-      ...this.account,
-      githubUsername: `${this.account.githubUsername}ausnsetuxiouicrgd`
-    })
   }
 }
 </script>

--- a/packages/fe/components/mobile-nav.vue
+++ b/packages/fe/components/mobile-nav.vue
@@ -184,7 +184,7 @@ export default {
   justify-content: flex-end;
 }
 
-:deep(.button) {
+:deep(.site-mobile-nav-link) {
   position: relative;
   padding: 0.125rem 0.125rem 0.125rem 1.5rem;
   z-index: 10000;
@@ -301,6 +301,7 @@ export default {
   justify-content: space-evenly;
   width: 100%;
   padding: 1.875rem 2rem;
+  z-index: 100000;
 }
 
 .auth-button {

--- a/packages/fe/components/mobile-nav.vue
+++ b/packages/fe/components/mobile-nav.vue
@@ -298,7 +298,7 @@ export default {
 .cta-button-list {
   display: flex;
   flex-direction: row;
-  justify-content: space-between;
+  justify-content: space-evenly;
   width: 100%;
   padding: 1.875rem 2rem;
 }

--- a/packages/fe/components/site-header.vue
+++ b/packages/fe/components/site-header.vue
@@ -409,6 +409,19 @@ export default {
 }
 
 :deep(.auth-button) {
+  .panel-left {
+    max-width: 10vw;
+  }
+    @include medium {
+      margin-right: .5rem;
+      .panel-left {
+        max-width: 40vw;
+      }
+    }
+  .username {
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
   .button {
     @include large {
       padding: 0.625rem 1rem;

--- a/packages/fe/components/site-header.vue
+++ b/packages/fe/components/site-header.vue
@@ -424,7 +424,7 @@ export default {
   }
   .button {
     @include large {
-      padding: 0.625rem 1rem;
+      padding: 0.625rem 0;
     }
   }
 }


### PR DESCRIPTION
Branch includes: 

- styles AuthButton with truncated username and ellipses if it would interfere with standard nav layout 
  - mobile and desktop styling
- style fix for this weird mobile nav bug
<img width="234" alt="Screenshot 2023-04-28 at 11 50 38" src="https://user-images.githubusercontent.com/30419893/235194883-94badfac-cc04-4c69-83f8-bbe29e5919e4.png">
