### PR TITLE
content: replace notaries with roadmap in nav

### DIFF
--- a/packages/fe/content/pages/general.json
+++ b/packages/fe/content/pages/general.json
@@ -13,15 +13,14 @@
     "home_link": "/apply",
     "header": [
       {
-        "type": "a",
-        "href": "https://notaries.datacapstats.io/",
-        "label": "Notaries",
-        "target": "_blank"
-      },
-      {
         "type": "nuxt-link",
         "href": "/about",
         "label": "About"
+      },
+      {
+        "type": "nuxt-link",
+        "href": "/#roadmap",
+        "label": "Roadmap"
       },
       {
         "type": "nuxt-link",


### PR DESCRIPTION
Minor top navigation update. Decided to keep the full word "documentation", since we have enough extra space for now and using short words actually threw off some of the nav canvas width calculations.