### PR TITLE
feat: open application indicator

### DIFF
--- a/packages/be/config.js
+++ b/packages/be/config.js
@@ -34,6 +34,10 @@ module.exports = {
     __dirname,
     env === 'development' ? '../../../' : '../../../../'
   ),
+  repos: {
+    ga: ['filecoin-project/filecoin-plus-client-onboarding', 'data-preservation-programs/filecoin-plus-client-onboarding'],
+    lda: ['filecoin-project/filecoin-plus-large-datasets', 'data-preservation-programs/filecoin-plus-large-datasets']
+  },
   // ============================================================= Server Config
   port: backendPort,
   frontendUrl: env === 'development' ? `${baseUrls[env]}:${frontendPort}` : baseUrls[env],

--- a/packages/be/modules/application/logic/get-application-list.js
+++ b/packages/be/modules/application/logic/get-application-list.js
@@ -5,16 +5,11 @@ const Axios = require('axios')
 
 const MC = require('@Root/config')
 
-const repos = {
-  ga: ['filecoin-project/filecoin-plus-client-onboarding', 'data-preservation-programs/filecoin-plus-client-onboarding'],
-  lda: ['filecoin-project/filecoin-plus-large-datasets', 'data-preservation-programs/filecoin-plus-large-datasets']
-}
-
 // ////////////////////////////////////////////////////////////////////// Export
 // -----------------------------------------------------------------------------
 module.exports = async (view, user, page = 1, state = 'all', limit = 10, sort = 'created') => {
   try {
-    const repo = MC.serverFlag === 'production' ? repos[view][0] : repos[view][1]
+    const repo = MC.serverFlag === 'production' ? MC.repos[view][0] : MC.repos[view][1]
     const options = {
       headers: { Accept: 'application/vnd.github+json', 'X-GitHub-Api-Version': '2022-11-28', Authorization: `Bearer ${user.githubToken}` },
       params: {

--- a/packages/be/modules/application/rest/get-open-application-count.js
+++ b/packages/be/modules/application/rest/get-open-application-count.js
@@ -1,0 +1,29 @@
+console.log('💡 [endpoint] /get-open-application-count')
+
+// ///////////////////////////////////////////////////////////////////// Imports
+// -----------------------------------------------------------------------------
+const { SendData, ThrowError } = require('@Module_Utilities')
+const GetApplicationList = require('@Module_Application/logic/get-application-list')
+const FindUser = require('@Module_User/logic/find-user')
+
+const MC = require('@Root/config')
+
+// //////////////////////////////////////////////////////////////////// Endpoint
+// -----------------------------------------------------------------------------
+MC.app.get('/get-open-application-count', async (req, res) => {
+  try {
+    const identifier = req.session.identifier
+    if (!identifier) { throw ThrowError(403, 'You are not logged in') }
+    const query = req.query
+    const view = query.view
+    const user = await FindUser({ _id: identifier.userId })
+    if (!user) { throw ThrowError(403, 'Something went wrong. Try logging in again.') }
+    const applicationList = await GetApplicationList(view, user, false, 'open', 100, false)
+    const count = applicationList.results.length
+    SendData(res, 200, 'Open application count retrieved succesfully', count > 0 ? count : false)
+  } catch (e) {
+    console.log('===================== [Endpoint: /get-open-application-count]')
+    console.log(e)
+    SendData(res, e.code || 422, e.message || 'Something went wrong, please try logging in again')
+  }
+})

--- a/packages/fe/components/page-application-history/view-toggler.vue
+++ b/packages/fe/components/page-application-history/view-toggler.vue
@@ -1,0 +1,226 @@
+<template>
+  <Filterer
+    v-slot="{ applyFilter, originalSelected }"
+    filter-key="view"
+    :is-single-selection="true"
+    :default-selection="1"
+    :options="options"
+    v-on="$listeners">
+
+    <div class="field-text">
+      Show
+    </div>
+
+    <FieldStandalone
+      v-slot="{ updateValue, field }"
+      field-key="view"
+      :scaffold="{
+        type: 'radio',
+        required: false,
+        label: 'Show',
+        options,
+        defaultValue: originalSelected,
+        updateGroupId: 'view',
+        isSingleSelection: true
+      }"
+      class="field-container"
+      v-on="$listeners">
+
+      <Radio
+        :field="field"
+        @updateValue="initializeFilter($event, updateValue, applyFilter)">
+
+        <template #radio-extra>
+          <div class="checker">
+            <div class="dot" />
+          </div>
+        </template>
+
+        <template #label="{ id, label }">
+          <div class="label">
+            <label :for="id">
+              {{ label }}
+            </label>
+            <div v-if="showIdentifier(label)" class="count" />
+          </div>
+        </template>
+
+      </Radio>
+
+    </FieldStandalone>
+
+  </Filterer>
+</template>
+
+<script>
+// ===================================================================== Imports
+import { mapGetters } from 'vuex'
+
+import Filterer from '@/modules/search/components/filterer'
+import FieldStandalone from '@/modules/form/components/field-standalone'
+import Radio from '@/modules/form/fields/radio'
+
+// ====================================================================== Export
+export default {
+  name: 'ViewToggler',
+
+  components: {
+    Filterer,
+    FieldStandalone,
+    Radio
+  },
+
+  props: {
+    options: {
+      type: Array,
+      required: true
+    }
+  },
+
+  computed: {
+    ...mapGetters({
+      view: 'account/view',
+      openCount: 'account/openCount'
+    })
+  },
+
+  methods: {
+    async initializeFilter (index, updateValue, applyFilter) {
+      updateValue(index)
+      await applyFilter({ index, live: false })
+      await this.$filter('page').for({ index: 0, live: false })
+      await this.$applyMultipleFiltersToQuery({ filters: ['page', 'view'] })
+    },
+    showIdentifier (label) {
+      if (this.openCount[label.toLowerCase()]) { return true }
+      return false
+    }
+  }
+}
+</script>
+
+<style lang="scss" scoped>
+$dimension: 1.625rem;
+
+@keyframes shrink-bounce {
+  0% { transform: scale(1); }
+  33% { transform: scale(0.85); }
+  100% { transform: scale(1); }
+}
+
+// ///////////////////////////////////////////////////////////////////// General
+.field-text {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-right: 1.125rem;
+  font-size: 1rem;
+  font-weight: 500;
+}
+
+.count {
+  display: flex;
+  flex-direction: row;
+  justify-content: center;
+  align-items: center;
+  position: absolute;
+  bottom: calc(100% - toRem(8));
+  left: 100%;
+  width: toRem(9);
+  height: toRem(9);
+  font-size: toRem(7);
+  font-weight: 700;
+  background-color: $dodgerBlue;
+  border-radius: 50%;
+  pointer-events: none;
+}
+
+.field-radio {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  cursor: pointer;
+}
+
+:deep(.radio-wrapper) {
+  position: relative;
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  cursor: pointer;
+  &:hover {
+    .checker {
+      transition: 150ms ease-in;
+      transform: scale(1.1);
+    }
+  }
+  &:not(:last-child) {
+    margin-right: 2.125rem;
+  }
+}
+
+:deep(.radio-container) {
+  position: relative;
+}
+
+:deep(.radio) {
+  display: flex;
+  position: relative;
+  width: $dimension;
+  height: $dimension;
+  opacity: 0;
+  cursor: pointer;
+  z-index: 10;
+  &:checked {
+    + .checker {
+      animation: shrink-bounce 150ms cubic-bezier(0.4, 0, 0.23, 1);
+      border-color: $nandor;
+      background-color: $racingGreen;
+      .dot {
+        display: block;
+      }
+    }
+  }
+  &:focus-visible {
+    + .checker {
+      @include focusBoxShadow;
+    }
+  }
+}
+
+.checker {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: $dimension;
+  height: $dimension;
+  border: 2px solid $nandor;
+  border-radius: 50%;
+  background-color: $racingGreen;
+  pointer-events: none;
+  z-index: 5;
+  transition: border-color 150ms, background-color 150ms, transform 150ms ease-out;
+}
+
+.dot {
+  display: none;
+  clip-path: circle(50%);
+  background: radial-gradient(50% 50% at 50% 50%, transparent 0%, $greenYellow 100%);
+  height: toRem(12);
+  width: toRem(12);
+}
+
+.label {
+  font-weight: 400;
+  padding-left: 1rem;
+  line-height: leading(26, 18);
+  cursor: pointer;
+  label {
+    cursor: pointer;
+  }
+}
+</style>

--- a/packages/fe/pages/account/_username/applications.vue
+++ b/packages/fe/pages/account/_username/applications.vue
@@ -26,7 +26,7 @@
                   class="filter-checkbox"
                   :options="filters.state"
                   @filterApplied="filterApplied" />
-                <Radio
+                <ViewToggler
                   class="filter-radio"
                   :options="filters.view_application_type" />
                 <Sort
@@ -95,7 +95,7 @@ import { mapActions, mapGetters } from 'vuex'
 import AppAccordion from '@/components/app-accordion'
 import ButtonA from '@/components/buttons/button-a'
 import Checkbox from '@/components/search/checkbox'
-import Radio from '@/components/search/radio'
+import ViewToggler from '@/components/page-application-history/view-toggler'
 import Sort from '@/components/search/sort'
 import PaginationControls from '@/components/search/pagination-controls'
 import Limit from '@/components/search/limit'
@@ -113,7 +113,7 @@ export default {
     AppAccordion,
     ButtonA,
     Checkbox,
-    Radio,
+    ViewToggler,
     Sort,
     PaginationControls,
     Limit,
@@ -186,6 +186,8 @@ export default {
         }
       }).catch(() => {})
     }
+    this.getOpenApplicationCount('lda')
+    this.getOpenApplicationCount('ga')
     this.$nuxt.$on('filtersApplied', (payload) => {
       if (this.account) {
         const filters = payload.filters
@@ -200,6 +202,7 @@ export default {
   methods: {
     ...mapActions({
       getApplicationList: 'account/getApplicationList',
+      getOpenApplicationCount: 'account/getOpenApplicationCount',
       setLoadingStatus: 'account/setLoadingStatus',
       setView: 'account/setView'
     }),

--- a/packages/fe/store/account.js
+++ b/packages/fe/store/account.js
@@ -13,6 +13,10 @@ const state = () => ({
     limit: 10,
     totalPages: 1
   },
+  openCount: {
+    ldn: false, // cannot be 'lda'
+    ga: false
+  },
   application: {
     organization_name: null,
     your_role: null,
@@ -71,7 +75,8 @@ const getters = {
   loading: state => state.loading,
   refresh: state => state.refresh,
   metadata: state => state.metadata,
-  view: state => state.view
+  view: state => state.view,
+  openCount: state => state.openCount
 }
 
 // ///////////////////////////////////////////////////////////////////// Actions
@@ -149,8 +154,7 @@ const actions = {
         { filterKey: 'limit' },
         { filterKey: 'sort' },
         { filterKey: 'state' },
-        { filterKey: 'view', default: getters.view },
-        { queryKey: 'user' }
+        { filterKey: 'view', default: getters.view }
       ])
       const response = await this.$axiosAuth.get('/get-application-list', { params })
       const payload = response.data.payload
@@ -164,6 +168,18 @@ const actions = {
       console.log(e)
       dispatch('setLoadingStatus', { type: 'loading', status: false })
       return false
+    }
+  },
+  // /////////////////////////////////////////////////// getOpenApplicationCount
+  async getOpenApplicationCount ({ commit, getters, dispatch }, view) {
+    try {
+      const response = await this.$axiosAuth.get('/get-open-application-count', {
+        params: { view }
+      })
+      commit('SET_OPEN_APPLICATION_COUNT', { view, count: response.data.payload })
+    } catch (e) {
+      console.log('=========== [Store Action: account/getOpenApplicationCount]')
+      console.log(e)
     }
   },
   // //////////////////////////////////////////////////////// setApplicationList
@@ -217,6 +233,9 @@ const mutations = {
   },
   SET_VIEW (state, view) {
     state.view = view
+  },
+  SET_OPEN_APPLICATION_COUNT (state, payload) {
+    state.openCount[payload.view === 'lda' ? 'ldn' : 'ga'] = payload.count
   }
 }
 


### PR DESCRIPTION
Application history page tabs now display an indicator that signifies whether or not the user has any currently **_open_** applications in each repo

<img width="970" alt="Screenshot 2023-05-24 at 7 55 06 AM" src="https://github.com/data-preservation-programs/filplus.storage/assets/11708190/cb414741-5706-4cd8-b23a-13ddb5907aba">
