### PR TITLE
fix: empty mailto and github user in notaries table

### DIFF
--- a/packages/fe/components/notaries-table.vue
+++ b/packages/fe/components/notaries-table.vue
@@ -139,6 +139,7 @@
 <script>
 // ===================================================================== Imports
 import { mapGetters } from 'vuex'
+import CloneDeep from 'lodash/cloneDeep'
 
 import FieldStandalone from '@/modules/form/components/field-standalone'
 import ButtonA from '@/components/buttons/button-a'
@@ -193,7 +194,7 @@ export default {
       return this.form.scaffold
     },
     notaryList () {
-      return this.staticFiles['notaries-list.json']
+      return CloneDeep(this.staticFiles['notaries-list.json'])
     },
     filteredNotaries () {
       const notaryList = this.notaryList
@@ -201,6 +202,8 @@ export default {
       const compiled = []
       for (let i = 0; i < len; i++) {
         const notary = notaryList[i]
+        notary.github_user = notary.github_user.filter(item => item !== '')
+        notary.email = notary.email.filter(item => item !== '')
         if ((notary.name !== '' || notary.organization !== '') && notary.status === 'Active' && notary.github_user.length > 0) {
           compiled.push(notary)
         }


### PR DESCRIPTION
The notaries table is pulled from this notaries list → https://raw.githubusercontent.com/keyko-io/filecoin-content/main/json/prod/verifiers-registry.json

As of this PR, the notaries list contains empty strings inside many of the `email` and `github_user` fields, like so:

```json
"email": ["email@example.com", "", ""],
"github_user": ["username123", ""],
```

This led to many blank entries being displayed on the frontend.