### PR TITLE
fix: website field now forces protocol

### DIFF
--- a/packages/fe/content/pages/apply-general.json
+++ b/packages/fe/content/pages/apply-general.json
@@ -56,6 +56,7 @@
           "tooltip": "Enter the full URL of your group or organization's website.",
           "required": true,
           "pre": "[^\\u0000-\\u00ff]",
+          "pattern": "https?:\/\/",
           "autocomplete": "none",
           "chars": {
             "min": 2,

--- a/packages/fe/content/pages/apply-large.json
+++ b/packages/fe/content/pages/apply-large.json
@@ -123,6 +123,7 @@
           "tooltip": "Provide the full URL of your group or organization's website",
           "required": true,
           "pre": "[^\\u0000-\\u00ff]",
+          "pattern": "https?:\/\/",
           "autocomplete": "none",
           "chars": {
             "min": 2,


### PR DESCRIPTION
`http(s)` followed by a `://` is now required for the `organization_website` field in both the GA and LDN applications