### PR TITLE
feat: allow KYC re-attempt if failed and record KYC history

### DIFF
--- a/packages/be/liftoff.js
+++ b/packages/be/liftoff.js
@@ -54,21 +54,10 @@ try {
 // const users = async () => {
 //   try {
 //     const user = await MC.model.User.findOne({ githubUsername: 'timelytree' })
+//     console.log(user)
 //     // const users = await MC.model.User.findById('')
 //     // const users = await MC.model.User.find().sort({ createdAt: 1 })
-//     // console.log(user.kyc.data)
 //     // console.log(users.length)
-//     // user.kyc = null
-//     // user.kyc = {
-//     //   event: 'success',
-//     //   error: {
-//     //     name: 'LifeProofValidationFailed',
-//     //     message: 'Failed to validate the life proof',
-//     //     custom: {
-//     //       identifier: 'timelytree'
-//     //     }
-//     //   }
-//     // }
 //     // user.hubspotOptIn = false
 //     // user.hubspotOptInContactId = undefined
 //     // user.hubspotOptInEmail = undefined
@@ -78,8 +67,8 @@ try {
 //     // user.hubspotOptInApplicationRegion = undefined
 //     // user.hubspotOptInApplicationDatacapRequested = undefined
 //     // user.hubspotOptInApplicationWalletAddress = undefined
-//     const saved = await user.save()
-//     console.log(saved)
+//     // const saved = await user.save()
+//     // console.log(saved)
 //   } catch (e) {
 //     console.log(e)
 //   }
@@ -90,6 +79,39 @@ try {
 //   //   console.log(e)
 //   // }
 // }; users()
+
+const kyc = async () => {
+  try {
+    // const users = await MC.model.User.find()
+    // const len = users.length
+    // for (let i = 0; i < len; i++) {
+    //   const user = users[i]
+    //   const kyc = user.kyc
+    //   if (kyc) {
+    //     user.kycHistory.push(kyc)
+    //     const saved = await user.save()
+    //     console.log(saved)
+    //   }
+    // }
+    // const user = await MC.model.User.findOne({ githubUsername: 'timelytree' })
+    // console.log(user)
+    // user.kyc = null
+    // user.kyc = {
+    //   event: 'success',
+    //   error: {
+    //     name: 'LifeProofValidationFailed',
+    //     message: 'Failed to validate the life proof',
+    //     custom: {
+    //       identifier: 'timelytree'
+    //     }
+    //   }
+    // }
+    // const saved = await user.save()
+    // console.log(saved)
+  } catch (e) {
+    console.log(e)
+  }
+}; kyc()
 
 // //////////////////////////////////////////////////////// lookupHubspotContact
 // const Axios = require('axios')

--- a/packages/be/liftoff.js
+++ b/packages/be/liftoff.js
@@ -51,46 +51,45 @@ try {
 
 // /////////////////////////////////////////////////////////////////////////////
 // -----------------------------------------------------------------------------
-const users = async () => {
-  try {
-    const user = await MC.model.User.findOne({ githubUsername: 'timelytree' })
-    // const users = await MC.model.User.findById('')
-    // const users = await MC.model.User.find().sort({ createdAt: 1 })
-    // console.log(user.kyc.data)
-    // console.log(users.length)
-    user.kyc = {
-      event: 'success',
-      error: {
-        name: 'LifeProofValidationFailed',
-        message: 'Failed to validate the life proof',
-        custom: {
-          email: 'info@dcent.nl',
-          environment: 'production',
-          identifier: 'cryptowhizzard'
-        }
-      }
-    }
-    // user.hubspotOptIn = false
-    // user.hubspotOptInContactId = undefined
-    // user.hubspotOptInEmail = undefined
-    // user.hubspotOptInFirstName = undefined
-    // user.hubspotOptInLastName = undefined
-    // user.hubspotOptInApplicationCompanyName = undefined
-    // user.hubspotOptInApplicationRegion = undefined
-    // user.hubspotOptInApplicationDatacapRequested = undefined
-    // user.hubspotOptInApplicationWalletAddress = undefined
-    const saved = await user.save()
-    console.log(saved)
-  } catch (e) {
-    console.log(e)
-  }
-  // try {
-  //   const user = await MC.model.User.deleteOne({ githubUsername: 'timelytree' })
-  //   console.log(user)
-  // } catch (e) {
-  //   console.log(e)
-  // }
-}; users()
+// const users = async () => {
+//   try {
+//     const user = await MC.model.User.findOne({ githubUsername: 'timelytree' })
+//     // const users = await MC.model.User.findById('')
+//     // const users = await MC.model.User.find().sort({ createdAt: 1 })
+//     // console.log(user.kyc.data)
+//     // console.log(users.length)
+//     // user.kyc = null
+//     // user.kyc = {
+//     //   event: 'failure',
+//     //   error: {
+//     //     name: 'LifeProofValidationFailed',
+//     //     message: 'Failed to validate the life proof',
+//     //     custom: {
+//     //       identifier: 'timelytree'
+//     //     }
+//     //   }
+//     // }
+//     // user.hubspotOptIn = false
+//     // user.hubspotOptInContactId = undefined
+//     // user.hubspotOptInEmail = undefined
+//     // user.hubspotOptInFirstName = undefined
+//     // user.hubspotOptInLastName = undefined
+//     // user.hubspotOptInApplicationCompanyName = undefined
+//     // user.hubspotOptInApplicationRegion = undefined
+//     // user.hubspotOptInApplicationDatacapRequested = undefined
+//     // user.hubspotOptInApplicationWalletAddress = undefined
+//     const saved = await user.save()
+//     console.log(saved)
+//   } catch (e) {
+//     console.log(e)
+//   }
+//   // try {
+//   //   const user = await MC.model.User.deleteOne({ githubUsername: 'timelytree' })
+//   //   console.log(user)
+//   // } catch (e) {
+//   //   console.log(e)
+//   // }
+// }; users()
 
 // //////////////////////////////////////////////////////// lookupHubspotContact
 // const Axios = require('axios')

--- a/packages/be/liftoff.js
+++ b/packages/be/liftoff.js
@@ -51,35 +51,46 @@ try {
 
 // /////////////////////////////////////////////////////////////////////////////
 // -----------------------------------------------------------------------------
-// const users = async () => {
-//   try {
-//     const user = await MC.model.User.findOne({ githubUsername: 'timelytree' })
-//     // const users = await MC.model.User.findById('')
-//     // const users = await MC.model.User.find().sort({ createdAt: 1 })
-//     // console.log(user.kyc.data)
-//     // console.log(users.length)
-//     // user.kyc = null
-//     // user.hubspotOptIn = false
-//     // user.hubspotOptInContactId = undefined
-//     // user.hubspotOptInEmail = undefined
-//     // user.hubspotOptInFirstName = undefined
-//     // user.hubspotOptInLastName = undefined
-//     // user.hubspotOptInApplicationCompanyName = undefined
-//     // user.hubspotOptInApplicationRegion = undefined
-//     // user.hubspotOptInApplicationDatacapRequested = undefined
-//     // user.hubspotOptInApplicationWalletAddress = undefined
-//     // const saved = await user.save()
-//     // console.log(saved)
-//   } catch (e) {
-//     console.log(e)
-//   }
-//   // try {
-//   //   const user = await MC.model.User.deleteOne({ githubUsername: 'timelytree' })
-//   //   console.log(user)
-//   // } catch (e) {
-//   //   console.log(e)
-//   // }
-// }; users()
+const users = async () => {
+  try {
+    const user = await MC.model.User.findOne({ githubUsername: 'timelytree' })
+    // const users = await MC.model.User.findById('')
+    // const users = await MC.model.User.find().sort({ createdAt: 1 })
+    // console.log(user.kyc.data)
+    // console.log(users.length)
+    user.kyc = {
+      event: 'success',
+      error: {
+        name: 'LifeProofValidationFailed',
+        message: 'Failed to validate the life proof',
+        custom: {
+          email: 'info@dcent.nl',
+          environment: 'production',
+          identifier: 'cryptowhizzard'
+        }
+      }
+    }
+    // user.hubspotOptIn = false
+    // user.hubspotOptInContactId = undefined
+    // user.hubspotOptInEmail = undefined
+    // user.hubspotOptInFirstName = undefined
+    // user.hubspotOptInLastName = undefined
+    // user.hubspotOptInApplicationCompanyName = undefined
+    // user.hubspotOptInApplicationRegion = undefined
+    // user.hubspotOptInApplicationDatacapRequested = undefined
+    // user.hubspotOptInApplicationWalletAddress = undefined
+    const saved = await user.save()
+    console.log(saved)
+  } catch (e) {
+    console.log(e)
+  }
+  // try {
+  //   const user = await MC.model.User.deleteOne({ githubUsername: 'timelytree' })
+  //   console.log(user)
+  // } catch (e) {
+  //   console.log(e)
+  // }
+}; users()
 
 // //////////////////////////////////////////////////////// lookupHubspotContact
 // const Axios = require('axios')

--- a/packages/be/liftoff.js
+++ b/packages/be/liftoff.js
@@ -60,7 +60,7 @@ try {
 //     // console.log(users.length)
 //     // user.kyc = null
 //     // user.kyc = {
-//     //   event: 'failure',
+//     //   event: 'success',
 //     //   error: {
 //     //     name: 'LifeProofValidationFailed',
 //     //     message: 'Failed to validate the life proof',

--- a/packages/be/modules/user/model/index.js
+++ b/packages/be/modules/user/model/index.js
@@ -88,7 +88,12 @@ const UserSchema = new Schema({
     type: Schema.Types.Mixed,
     required: false,
     default: null
-  }
+  },
+  kycHistory: [{
+    type: Schema.Types.Mixed,
+    required: false,
+    default: []
+  }]
 }, {
   timestamps: true,
   minimize: false,

--- a/packages/be/modules/user/rest/post-kyc-result.js
+++ b/packages/be/modules/user/rest/post-kyc-result.js
@@ -13,12 +13,12 @@ const serverFlag = MC.serverFlag
 // -----------------------------------------------------------------------------
 MC.app.post('/post-kyc-result', async (req, res) => {
   try {
+    const kyc = req.body
     if (serverFlag === 'stable') {
       console.log('========================================== /post-kyc-result')
-      console.log(req.body)
+      console.log(kyc)
     }
-    const body = req.body
-    let data = body.data
+    let data = kyc.data
     if (!data || data === '') {
       return SendData(res, 422, '<data> key is missing')
     }
@@ -35,7 +35,9 @@ MC.app.post('/post-kyc-result', async (req, res) => {
     if (!user) {
       return SendData(res, 422, 'Could not find user associated with <identifier>', { identifier: githubUsername })
     }
-    const saved = await UpdateUser({ _id: user._id, kyc: req.body })
+    const kycHistory = user.kycHistory
+    kycHistory.push(kyc)
+    const saved = await UpdateUser({ _id: user._id, kyc, kycHistory })
     MC.socket.io.to(`${saved._id}`).emit('module|kyc-updated|payload', saved)
     SendData(res, 200, 'KYC result recorded successfully', saved)
   } catch (e) {

--- a/packages/fe/components/auth-button.vue
+++ b/packages/fe/components/auth-button.vue
@@ -260,6 +260,9 @@ export default {
       }
     }
   }
+  .tooltip-content-wrapper {
+    display: none;
+  }
 }
 
 :deep(.button-logout.button-x) {

--- a/packages/fe/components/hero-b.vue
+++ b/packages/fe/components/hero-b.vue
@@ -32,7 +32,8 @@
           <div class="panel-right">
 
             <template v-if="account">
-              <div v-if="!account.kyc || account.kyc && account.kyc.event !== 'failure'" class="kyc">
+              <!-- <div v-if="!account.kyc || account.kyc && account.kyc.event !== 'failure'" class="kyc"> -->
+              <div class="kyc">
                 <div class="kyc-heading" v-html="kycHeading" />
                 <KycButton
                   tooltip-align="top"

--- a/packages/fe/components/kyc-button.vue
+++ b/packages/fe/components/kyc-button.vue
@@ -110,15 +110,13 @@ export default {
       return `${this.$config.togggleLink}&identifier=${this.account.githubUsername}`
     },
     tooltip () {
-      const status = this.status
       let tooltip = this.kycButton.tooltip
       if (!tooltip) { return false }
-      switch (status) {
-        case 'unverified' : tooltip = tooltip.replace('|link|', `<a href="${this.togggleLink}" target="_blank">Start KYC</a>.`); break
-        case 'verifying' : tooltip = tooltip.replace('|link|', `<a href="${this.togggleLink}" target="_blank">Check Status</a>.`); break
-        // case 'failure' : tooltip = tooltip.replace('|link|', `<a href="${this.togggleLink}" target="_blank">reach out</a>`); break
-        case 'failure' : tooltip = tooltip.replace('|link|', `<a href="${this.togggleLink}" target="_blank">try again</a>`); break
-      }
+      tooltip = tooltip.replaceAll('|Start_kyc_link|', `<a href="${this.togggleLink}" target="_blank">Start KYC</a>`)
+      tooltip = tooltip.replaceAll('|start_kyc_link|', `<a href="${this.togggleLink}" target="_blank">start KYC</a>`)
+      tooltip = tooltip.replaceAll('|Check_status_link|', `<a href="${this.togggleLink}" target="_blank">Check status</a>`)
+      tooltip = tooltip.replaceAll('|reach_out_link|', `<a href="${this.togggleLink}" target="_blank">reach out</a>`)
+      tooltip = tooltip.replaceAll('|try_again_link|', `<a href="${this.togggleLink}" target="_blank">try again</a>`)
       return tooltip
     }
   }

--- a/packages/fe/components/kyc-button.vue
+++ b/packages/fe/components/kyc-button.vue
@@ -84,15 +84,18 @@ export default {
       return kyc.event
     },
     hideButton () {
-      return this.theme === 'bare' && this.status === 'failure'
+      // return this.theme === 'bare' && this.status === 'failure'
+      return false
     },
     showExternalLinkIcon () {
       const status = this.status
-      return status === 'unverified' || status === 'verifying'
+      // return status === 'unverified' || status === 'verifying'
+      return status === 'unverified' || status === 'verifying' || status === 'failure'
     },
     kycButtonType () {
       const status = this.status
-      return status === 'success' || status === 'failure' ? 'div' : 'a'
+      // return status === 'success' || status === 'failure' ? 'div' : 'a'
+      return status === 'success' ? 'div' : 'a'
     },
     kycButtonContent () {
       return this.siteContent.general.navigation.kyc_button
@@ -113,7 +116,8 @@ export default {
       switch (status) {
         case 'unverified' : tooltip = tooltip.replace('|link|', `<a href="${this.togggleLink}" target="_blank">Start KYC</a>.`); break
         case 'verifying' : tooltip = tooltip.replace('|link|', `<a href="${this.togggleLink}" target="_blank">Check Status</a>.`); break
-        case 'failure' : tooltip = tooltip.replace('|link|', `<a href="${this.togggleLink}" target="_blank">reach out</a>`); break
+        // case 'failure' : tooltip = tooltip.replace('|link|', `<a href="${this.togggleLink}" target="_blank">reach out</a>`); break
+        case 'failure' : tooltip = tooltip.replace('|link|', `<a href="${this.togggleLink}" target="_blank">try again</a>`); break
       }
       return tooltip
     }
@@ -183,8 +187,8 @@ export default {
   &.failure {
     padding: 3px toRem(17);
   }
-  &.success,
-  &.failure {
+  &.success/*,
+  &.failure*/ {
     cursor: no-drop;
     &:hover {
       transform: none;
@@ -193,11 +197,11 @@ export default {
   &.verifying {
     font-style: italic;
   }
-  &.failure {
-    background-color: $aztec;
-    border-color: $nandor;
-    color: $nandor;
-  }
+  // &.failure {
+  //   background-color: $aztec;
+  //   border-color: $nandor;
+  //   color: $nandor;
+  // }
   .link-text {
     font-weight: 500;
   }

--- a/packages/fe/content/pages/general.json
+++ b/packages/fe/content/pages/general.json
@@ -37,19 +37,19 @@
     "kyc_button": {
       "unverified": {
         "text": "Confirm Identity",
-        "tooltip": "Optionally, you can get DataCap even faster by performing KYC verification through Togggle. KYC is not required. However, applicants that have passed KYC are more likely to be approved quickly. You’ll only need to perform KYC once. It will be applied to every application you make moving forward. |link|"
+        "tooltip": "Optionally, you can get DataCap even faster by performing KYC verification through Togggle. KYC is not required. However, applicants that have passed KYC are more likely to be approved quickly. You’ll only need to perform KYC once. It will be applied to every application you make moving forward. |Start_kyc_link|."
       },
       "verifying": {
         "text": "Verifying...",
-        "tooltip": "It looks like your KYC verification is currently in progress. |link|"
+        "tooltip": "It looks like your KYC verification is currently in progress. |Check_status_link| by entering the email you used for your submission."
       },
       "failure_original_message": {
         "text": "Verification not available",
-        "tooltip": "You are not eligible for KYC verification at this time. If you feel that this is a mistake, please |link| to the Filecoin plus team."
+        "tooltip": "You are not eligible for KYC verification at this time. If you feel that this is a mistake, please |reach_out_link| to the Filecoin plus team."
       },
       "failure": {
         "text": "Confirm Identity",
-        "tooltip": "You attempted but failed KYC. Please |link| or reach out for more information. The most likely reasons for failing are due to poor lighting or bad/blurry photos."
+        "tooltip": "You attempted but failed KYC. Please |try_again_link| or |reach_out_link| for more information. The most likely reasons for failing are due to poor lighting or bad/blurry photos."
       },
       "success": {
         "text": "Verified User",

--- a/packages/fe/content/pages/general.json
+++ b/packages/fe/content/pages/general.json
@@ -43,9 +43,13 @@
         "text": "Verifying...",
         "tooltip": "It looks like your KYC verification is currently in progress. |link|"
       },
-      "failure": {
+      "failure_original_message": {
         "text": "Verification not available",
         "tooltip": "You are not eligible for KYC verification at this time. If you feel that this is a mistake, please |link| to the Filecoin plus team."
+      },
+      "failure": {
+        "text": "Confirm Identity",
+        "tooltip": "You attempted but failed KYC. Please |link| or reach out for more information. The most likely reasons for failing are due to poor lighting or bad/blurry photos."
       },
       "success": {
         "text": "Verified User",


### PR DESCRIPTION
Previously, if users failed KYC, they were not allowed to try again. Now, they see the same `Confirm Identity` button as before, except with a different tooltip message.

- Most KYC tooltip text has been updated
- Fixed an issue with a tooltip appearing in the auth button
- All KYC submissions are now saved to a `kycHistory` key