### PR TITLE
feat: references to `inReview` changed to more generic `reviewing`

### DIFF
--- a/packages/be/crons/application-stats.js
+++ b/packages/be/crons/application-stats.js
@@ -101,7 +101,7 @@ const iterateApplications = (applications, applicationType) => {
   console.log(`🦊 iterating over ${applicationType} applications`)
   try {
     const states = {
-      inReview: 0,
+      reviewing: 0,
       validated: 0,
       completed: 0
     }
@@ -156,7 +156,7 @@ const ApplicationStats = async () => {
 
     const data = {
       states: {
-        inReview: gaStats.states.inReview + ldaStats.states.inReview,
+        reviewing: gaStats.states.reviewing + ldaStats.states.reviewing,
         validated: gaStats.states.validated + ldaStats.states.validated,
         completed: gaStats.states.completed + ldaStats.states.completed,
         segmented: {

--- a/packages/be/modules/application/logic/determine-application-state.js
+++ b/packages/be/modules/application/logic/determine-application-state.js
@@ -8,15 +8,15 @@ module.exports = (labels, applicationType) => {
   try {
     const completedRegex = { ga: /(state:)?\s?granted/gi, lda: /total\s?datacap\s?reached/gi }
     const validatedRegex = { ga: /(bot:)?\s?looking\s?good/gi, lda: /validated/ }
-    const inReviewRegex = { ga: /(state)|(bot)?:\s?(further\s?info)?(review)?\s?needed/gi, lda: /error/ }
+    const reviewingRegex = { ga: /(state)|(bot)?:\s?(further\s?info)?(review)?\s?needed/gi, lda: /error/ }
 
     const completed = HasLabel(labels, completedRegex[applicationType])
     const validated = HasLabel(labels, validatedRegex[applicationType])
-    const inReview = HasLabel(labels, inReviewRegex[applicationType])
+    const reviewing = HasLabel(labels, reviewingRegex[applicationType])
 
     return completed ? 'completed'
       : validated ? 'validated'
-        : inReview ? 'inReview'
+        : reviewing ? 'reviewing'
           : 'noRelevantLabels'
   } catch (e) {
     console.log('========================== [Logic: DetermineApplicationState]')


### PR DESCRIPTION
Application dashboard stats references to `inReview` have been changed to a more generic `reviewing`