### PR TITLE
feat: implemented `/get-kyc-submission-list` endpoint

### DIFF
--- a/packages/be/modules/application/rest/get-kyc-submission-list.js
+++ b/packages/be/modules/application/rest/get-kyc-submission-list.js
@@ -1,0 +1,35 @@
+console.log('💡 [endpoint] /get-kyc-submission-list')
+
+// ///////////////////////////////////////////////////////////////////// Imports
+// -----------------------------------------------------------------------------
+const { SendData, ThrowError } = require('@Module_Utilities')
+
+const MC = require('@Root/config')
+
+// //////////////////////////////////////////////////////////////////// Endpoint
+// -----------------------------------------------------------------------------
+MC.app.get('/get-kyc-submission-list', async (req, res) => {
+  try {
+    const params = req.query
+    const token = req.query.token
+    if (!token || token === '' || token !== process.env.GET_KYC_SUBMISSION_LIST_TOKEN) {
+      throw ThrowError(401, 'Please provide the correct token in the params: ?token=<token>')
+    }
+    const list = await MC.model.User
+      .find({ kyc: { $ne: null } })
+      .select({
+        githubUsername: 1,
+        'kyc.event': 1,
+        'kyc.error': 1,
+        'kyc.data.kyc.createdAt': 1,
+        'kyc.data.kyc.custom': 1
+      })
+    SendData(res, 200, 'Open application count retrieved succesfully', list)
+  } catch (e) {
+    if (process.serverFlag !== 'production') {
+      console.log('====================== [Endpoint: /get-kyc-submission-list]')
+      console.log(e)
+    }
+    SendData(res, e.code || 422, e.message || 'Something went wrong, please try logging in again')
+  }
+})

--- a/packages/be/modules/application/rest/get-kyc-submission-list.js
+++ b/packages/be/modules/application/rest/get-kyc-submission-list.js
@@ -10,7 +10,6 @@ const MC = require('@Root/config')
 // -----------------------------------------------------------------------------
 MC.app.get('/get-kyc-submission-list', async (req, res) => {
   try {
-    const params = req.query
     const token = req.query.token
     if (!token || token === '' || token !== process.env.GET_KYC_SUBMISSION_LIST_TOKEN) {
       throw ThrowError(401, 'Please provide the correct token in the params: ?token=<token>')
@@ -22,7 +21,7 @@ MC.app.get('/get-kyc-submission-list', async (req, res) => {
         'kyc.event': 1,
         'kyc.error': 1,
         'kyc.data.kyc.createdAt': 1,
-        'kyc.data.kyc.custom': 1
+        'kyc.data.custom': 1
       })
     SendData(res, 200, 'Open application count retrieved succesfully', list)
   } catch (e) {

--- a/packages/be/modules/user/model/index.js
+++ b/packages/be/modules/user/model/index.js
@@ -99,7 +99,8 @@ const UserSchema = new Schema({
   minimize: false,
   toObject: { getters: true, setters: true },
   toJSON: { getters: true, setters: true },
-  runSettersOnQuery: true
+  runSettersOnQuery: true,
+  id: false
 })
 
 // ///////////////////////////////////////////////////////////////////// Plugins


### PR DESCRIPTION
This endpoint outputs a list of all KYC submissions in the database, regardless of status. The `user.kyc` object has been stripped down to only the most relevant information.