### PR TITLE
feat: KYC success/approve/failure submissions now push a notification

### DIFF
--- a/packages/be/modules/notification/model/index.js
+++ b/packages/be/modules/notification/model/index.js
@@ -17,7 +17,8 @@ const NotificationSchema = new Schema({
     type: String,
     required: true,
     enum: [
-      'application'
+      'application',
+      'kyc'
     ]
   },
   read: {

--- a/packages/be/modules/notification/queries/get-notification-list.js
+++ b/packages/be/modules/notification/queries/get-notification-list.js
@@ -28,6 +28,7 @@ module.exports = (page = 1, limit = 10, userId) => {
       $project: {
         read: 1,
         custom: 1,
+        bucket: 1,
         createdAt: 1
       }
     },

--- a/packages/be/modules/user/rest/post-kyc-result.js
+++ b/packages/be/modules/user/rest/post-kyc-result.js
@@ -5,6 +5,7 @@ console.log('💡 [endpoint] /post-kyc-result')
 const { SendData } = require('@Module_Utilities')
 const FindUser = require('@Module_User/logic/find-user')
 const UpdateUser = require('@Module_User/logic/update-user')
+const PushNotification = require('@Module_Notification/logic/push-notification')
 
 const MC = require('@Root/config')
 const serverFlag = MC.serverFlag
@@ -16,6 +17,7 @@ MC.app.post('/post-kyc-result', async (req, res) => {
     const kyc = req.body
     console.log('============================================ /post-kyc-result')
     console.log(kyc)
+    // ------------------------------------------------------------ run checkers
     let data = kyc.data || kyc.error
     if (!data || data === '') {
       return SendData(res, 422, '<data> key is missing')
@@ -33,10 +35,34 @@ MC.app.post('/post-kyc-result', async (req, res) => {
     if (!user) {
       return SendData(res, 422, 'Could not find user associated with <identifier>', { identifier: githubUsername })
     }
+    // -------------------------------------------------------- populate history
     const kycHistory = user.kycHistory
     kycHistory.push(kyc)
     const saved = await UpdateUser({ _id: user._id, kyc, kycHistory })
     MC.socket.io.to(`${saved._id}`).emit('module|kyc-updated|payload', saved)
+    // ------------------------------------------------------- push notification
+    const notification = {
+      ownerId: user._id,
+      bucket: 'kyc',
+      read: false,
+      custom: {
+        event: kyc.event,
+        success: null,
+        failure: null
+      }
+    }
+    if (kyc.event === 'success' || kyc.event === 'approve') {
+      notification.custom.success = {
+        createdAt: kyc.data.kyc.createdAt
+      }
+    } else if (kyc.event === 'failure') {
+      notification.custom.failure = {
+        name: kyc.error.name,
+        message: kyc.error.message
+      }
+    }
+    await PushNotification(notification)
+    // -------------------------------------------------------------------- send
     SendData(res, 200, 'KYC result recorded successfully', saved)
   } catch (e) {
     console.log('================================ [Endpoint: /post-kyc-result]')

--- a/packages/fe/components/navigation/notification-application.vue
+++ b/packages/fe/components/navigation/notification-application.vue
@@ -1,0 +1,86 @@
+<template>
+  <div class="notification-application">
+
+    <div class="notification-heading">
+      {{ stateMap[notification.custom.state] }}
+    </div>
+
+    <div class="message">
+      <a
+        :href="notification.custom.issueUrl"
+        class="issue-link"
+        target="_blank">
+        Issue #{{ notification.custom.issueNumber }}</a>:{{ notification.custom.issueTitle }}
+    </div>
+
+    <Timeago
+      v-slot="{ convertedDate }"
+      :date="new Date(notification.createdAt)">
+      <div class="timeago">
+        {{ convertedDate }}
+      </div>
+    </Timeago>
+
+  </div>
+</template>
+
+<script>
+// ===================================================================== Imports
+import Timeago from '@/components/timeago'
+
+// ====================================================================== Export
+export default {
+  name: 'NotificationApplication',
+
+  components: {
+    Timeago
+  },
+
+  props: {
+    notification: {
+      type: Object,
+      required: true
+    }
+  },
+
+  data () {
+    return {
+      stateMap: {
+        new: 'New Application',
+        completed: 'Completed',
+        validated: 'Validated',
+        reviewing: 'In Review'
+      }
+    }
+  }
+}
+</script>
+
+<style lang="scss" scoped>
+// ///////////////////////////////////////////////////////////////////// General
+.notification-heading,
+.message {
+  margin-bottom: toRem(5);
+  font-size: 1rem;
+  line-height: leading(24, 16);
+}
+
+.issue-link {
+  font-size: inherit;
+  font-weight: 500;
+  color: $greenYellow;
+  &:hover {
+    text-decoration: underline;
+  }
+}
+
+.notification-heading {
+  font-weight: 600;
+}
+
+.timeago {
+  font-size: toRem(14);
+  line-height: leading(18, 14);
+  color: $nandor;
+}
+</style>

--- a/packages/fe/components/navigation/notification-kyc.vue
+++ b/packages/fe/components/navigation/notification-kyc.vue
@@ -1,0 +1,197 @@
+<template>
+  <div class="notification-kyc">
+
+    <!-- Heading -->
+    <div class="notification-heading">
+      KYC {{ stateMap[notification.custom.event] }}
+    </div>
+
+    <!-- Message -->
+    <div :class="['message', notification.custom.event]">
+      <!-- Success/Approve -->
+      <template v-if="notification.custom.event !== 'failure'">
+        <IconKycSuccess class="icon-kyc-success" />
+        {{ getKycButtonText(notification.custom.event) }}
+      </template>
+      <!-- Failure -->
+      <template v-else>
+        <div class="error-name">
+          {{ notification.custom.failure.name }}
+        </div>
+        <div class="error-message">
+          {{ notification.custom.failure.message }}
+        </div>
+        <ButtonX
+          :to="togggleLink"
+          class="kyc-button"
+          tag="a"
+          target="_blank">
+          <div class="link-text">
+            Confirm identity
+          </div>
+          <IconLinkExternal class="icon-link-external" />
+        </ButtonX>
+      </template>
+    </div>
+
+    <!-- Timeago -->
+    <Timeago
+      v-slot="{ convertedDate }"
+      :date="new Date(notification.createdAt)">
+      <div class="timeago">
+        {{ convertedDate }}
+      </div>
+    </Timeago>
+
+  </div>
+</template>
+
+<script>
+// ===================================================================== Imports
+import { mapGetters } from 'vuex'
+
+import Timeago from '@/components/timeago'
+import ButtonX from '@/components/buttons/button-x'
+
+import IconKycSuccess from '@/components/icons/kyc-success'
+import IconLinkExternal from '@/components/icons/link-external'
+
+// ====================================================================== Export
+export default {
+  name: 'NotificationApplication',
+
+  components: {
+    Timeago,
+    ButtonX,
+    IconKycSuccess,
+    IconLinkExternal
+  },
+
+  props: {
+    notification: {
+      type: Object,
+      required: true
+    }
+  },
+
+  data () {
+    return {
+      stateMap: {
+        failure: 'Failed',
+        success: 'Successful',
+        approve: 'Successful'
+      }
+    }
+  },
+
+  computed: {
+    ...mapGetters({
+      siteContent: 'general/siteContent',
+      account: 'auth/account'
+    }),
+    kycButtonContent () {
+      return this.siteContent.general.navigation.kyc_button
+    },
+    togggleLink () {
+      return `${this.$config.togggleLink}&identifier=${this.account.githubUsername}`
+    }
+  },
+
+  methods: {
+    getKycButtonText (status) {
+      return this.kycButtonContent[status].text
+    }
+  }
+}
+</script>
+
+<style lang="scss" scoped>
+// ///////////////////////////////////////////////////////////////////// General
+.notification-heading,
+.message {
+  margin-bottom: toRem(5);
+  font-size: 1rem;
+  line-height: leading(24, 16);
+}
+
+.issue-link {
+  font-size: inherit;
+  font-weight: 500;
+  color: $greenYellow;
+  &:hover {
+    text-decoration: underline;
+  }
+}
+
+.notification-heading {
+  font-weight: 600;
+}
+
+.message,
+.link-text,
+.error-name {
+  font-size: toRem(14);
+  font-weight: 500;
+  line-height: 1;
+}
+
+.message {
+  &:not(.failure) {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+  }
+  &.failure {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+  }
+}
+
+.icon-kyc-success {
+  width: toRem(15);
+  height: toRem(15);
+  margin-right: 0.5rem;
+}
+
+.icon-link-external {
+  width: toRem(13);
+  height: toRem(13);
+  margin-bottom: toRem(2);
+  margin-left: toRem(6);
+}
+
+.error-name {
+  color: $mandysPink;
+  margin-top: 0.5rem;
+}
+
+.error-message {
+  margin-bottom: 0.5rem;
+  font-size: 1rem;
+  line-height: leading(24, 16);
+}
+
+:deep(.kyc-button) {
+  margin-bottom: 0.25rem;
+  &:hover {
+    .link-text {
+      text-decoration: underline;
+    }
+  }
+  .button-content {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+  }
+  .link-text {
+    color: $greenYellow;
+  }
+}
+
+.timeago {
+  font-size: toRem(14);
+  line-height: leading(18, 14);
+  color: $nandor;
+}
+</style>

--- a/packages/fe/components/navigation/notification-panel.vue
+++ b/packages/fe/components/navigation/notification-panel.vue
@@ -53,25 +53,15 @@
                 <span class="read-status-indicator" />
               </component>
 
-              <div class="panel-right">
-                <div class="notification-heading">
-                  {{ stateMap[notification.custom.state] }}
-                </div>
-                <div class="message">
-                  <a
-                    :href="notification.custom.issueUrl"
-                    class="issue-link"
-                    target="_blank">
-                    Issue #{{ notification.custom.issueNumber }}</a>:{{ notification.custom.issueTitle }}
-                </div>
-                <Timeago
-                  v-slot="{ convertedDate }"
-                  :date="new Date(notification.createdAt)">
-                  <div class="timeago">
-                    {{ convertedDate }}
-                  </div>
-                </Timeago>
-              </div>
+              <NotificationApplication
+                v-if="notification.bucket === 'application'"
+                :notification="notification"
+                class="panel-right" />
+
+              <NotificationKyc
+                v-else-if="notification.bucket === 'kyc'"
+                :notification="notification"
+                class="panel-right" />
 
             </div>
           </div>
@@ -127,7 +117,8 @@
 import { mapGetters, mapActions } from 'vuex'
 
 import DropdownPanel from '@/components/dropdown-panel'
-import Timeago from '@/components/timeago'
+import NotificationApplication from '@/components/navigation/notification-application'
+import NotificationKyc from '@/components/navigation/notification-kyc'
 import Spinner from '@/components/spinners/material-circle'
 
 import IconBell from '@/components/icons/bell'
@@ -140,7 +131,8 @@ export default {
 
   components: {
     DropdownPanel,
-    Timeago,
+    NotificationApplication,
+    NotificationKyc,
     Spinner,
     IconBell,
     IconCloseThick,
@@ -150,12 +142,6 @@ export default {
   data () {
     return {
       notificationsLoaded: false,
-      stateMap: {
-        new: 'New Application',
-        completed: 'Completed',
-        validated: 'Validated',
-        reviewing: 'In Review'
-      },
       timeout: null,
       scrull: null,
       displayGradient: 'bottom'
@@ -535,32 +521,6 @@ export default {
 
 .panel-right {
   flex: 1;
-}
-
-.notification-heading,
-.message {
-  margin-bottom: toRem(5);
-  font-size: 1rem;
-  line-height: leading(24, 16);
-}
-
-.issue-link {
-  font-size: inherit;
-  font-weight: 500;
-  color: $greenYellow;
-  &:hover {
-    text-decoration: underline;
-  }
-}
-
-.notification-heading {
-  font-weight: 600;
-}
-
-.timeago {
-  font-size: toRem(14);
-  line-height: leading(18, 14);
-  color: $nandor;
 }
 
 .footer {


### PR DESCRIPTION
KYC submissions now push a notification. Failures allow users to re-try KYC directly from the notification panel.

<img width="402" alt="Screenshot 2023-07-26 at 4 18 52 PM" src="https://github.com/data-preservation-programs/filplus.storage/assets/11708190/2cafe586-22c1-4289-8a11-ec58f5451919">
