### PR TITLE
feat: application history page now displays application progress bar

### DIFF
--- a/packages/be/modules/application/logic/get-application-list.js
+++ b/packages/be/modules/application/logic/get-application-list.js
@@ -2,6 +2,7 @@
 // -----------------------------------------------------------------------------
 const { ParseLinkHeader } = require('@Module_Utilities')
 const Axios = require('axios')
+const DetermineApplicationState = require('@Module_Application/logic/determine-application-state')
 
 const MC = require('@Root/config')
 
@@ -27,7 +28,8 @@ module.exports = async (view, user, page = 1, state = 'all', limit = 10, sort = 
       results: response.data.map((application) => {
         return {
           ...application,
-          type: view === 'ga' ? 'GA (General Application)' : 'LDN (Large Dataset Application)'
+          type: view === 'ga' ? 'GA (General Application)' : 'LDN (Large Dataset Application)',
+          application_state: DetermineApplicationState(application.labels.map(label => (label.name)), view)
         }
       })
     }

--- a/packages/fe/components/app-accordion.vue
+++ b/packages/fe/components/app-accordion.vue
@@ -17,27 +17,40 @@
           :active="active">
 
           <AccordionHeader>
-            <div class="header-top-row">
-              <div class="header-title-wrapper">
-                <IconApplicationOpen
-                  v-if="entry.state === 'open' "
-                  class="application-icon" />
-                <IconApplicationRejected
-                  v-if="entry.state === 'closed' && entry.state_reason === 'not_planned' "
-                  class="application-icon" />
-                <IconApplicationAccepted
-                  v-if="entry.state === 'closed' && entry.state_reason === 'completed' "
-                  class="application-icon" />
-                <h2 class="header-title h5" v-html="entry.title" />
-              </div>
-              <p class="application-type p2" v-html="entry.type" />
+            <div class="state-icon-wrapper">
+              <IconApplicationOpen
+                v-if="entry.state === 'open'"
+                class="state-icon" />
+              <IconApplicationRejected
+                v-if="entry.state === 'closed' && entry.state_reason === 'not_planned'"
+                class="state-icon" />
+              <IconApplicationAccepted
+                v-if="entry.state === 'closed' && entry.state_reason === 'completed'"
+                class="state-icon" />
             </div>
-            <Timeago
-              v-slot="{ convertedDate }"
-              :date="getDate(entry)">
-              <h3 class="header-subtitle p1" v-html="generateSubtitle(entry, convertedDate)" />
-            </Timeago>
-            <span class="expand-application-text p2">
+            <div class="header-content">
+              <div class="panel-left">
+                <h2 class="header-title h5" v-html="entry.title" />
+                <Timeago
+                  v-slot="{ convertedDate }"
+                  :date="getDate(entry)">
+                  <h3 class="header-subtitle p1" v-html="generateSubtitle(entry, convertedDate)" />
+                </Timeago>
+              </div>
+              <div class="panel-right">
+                <div class="application-type p2" v-html="entry.type" />
+                <div :class="['application-progress', entry.application_state]">
+                  <span
+                    v-for="(value, key) in stateMap"
+                    :key="`application-progress-state-${key}`"
+                    :class="['step', key, { highlight: key === entry.application_state }]" />
+                </div>
+                <div class="application-state">
+                  {{ stateMap[entry.application_state] }}
+                </div>
+              </div>
+            </div>
+            <div class="expand-application-text p2">
               <IconChevron />
               <span v-html="expandApplicationText" />
               <ButtonX
@@ -47,7 +60,7 @@
                 theme="green">
                 <div class="text" v-html="viewOnGithubText" />
               </ButtonX>
-            </span>
+            </div>
           </AccordionHeader>
 
           <AccordionContent>
@@ -135,7 +148,13 @@ export default {
 
   data () {
     return {
-      renderer: false
+      renderer: false,
+      stateMap: {
+        noRelevantLabels: 'Not Started',
+        reviewing: 'In Review',
+        validated: 'Validated',
+        completed: 'Completed'
+      }
     }
   },
 
@@ -213,18 +232,31 @@ export default {
 }
 
 .accordion-header {
+  position: relative;
   cursor: pointer;
   padding: 1.25rem 0;
 }
 
-.header-top-row {
+.state-icon-wrapper {
   display: flex;
-  justify-content: space-between;
+  flex-direction: column;
+  align-items: center;
+  position: absolute;
+  top: 0;
+  left: -3.875rem;
+  width: 3.875rem;
+  padding-top: toRem(26);
 }
 
-.header-title-wrapper {
+.state-icon {
+  width: toRem(18);
+  height: toRem(18);
+}
+
+.header-content {
   display: flex;
-  align-items: flex-start;
+  flex-direction: row;
+  justify-content: space-between;
 }
 
 .header-title {
@@ -232,16 +264,73 @@ export default {
   letter-spacing: 0;
 }
 
-.application-icon {
-  width: toRem(18);
-  height: toRem(18);
-  margin-top: toRem(6);
-  margin-right: 1.25rem;
-  margin-left: -2.5rem;
+.panel-right {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
 }
 
 .application-type {
   white-space: nowrap;
+}
+
+@mixin applicationProgressStepHighlighted {
+  background-color: $greenYellow;
+  color: $aztec;
+  border-color: $greenYellow;
+}
+
+.application-progress {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  margin: 0.5rem 0;
+  .step {
+    @include applicationProgressStepHighlighted;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    position: relative;
+    width: 1rem;
+    height: 1rem;
+    border-radius: 50%;
+    border: 1px solid;
+    transition: 150ms ease-in;
+    &:not(:first-child) {
+      margin-left: calc(#{toRem(19)} + #{toRem(3 * 2)});
+      &:before {
+        display: block;
+        content: '';
+        position: absolute;
+        top: toRem(5);
+        right: calc(100% + #{toRem(4)});
+        width: toRem(19);
+        height: toRem(3);
+        border-radius: toRem(3);
+        background-color: $nandor;
+      }
+    }
+    &.noRelevantLabels:after { content: '-'; }
+    &.reviewing:after { content: '1'; }
+    &.validated:after { content: '2'; }
+    &.completed:after { content: '3'; }
+    &:after {
+      font-size: toRem(9);
+      line-height: 1;
+    }
+    &.highlight ~ * {
+      background-color: $aztec;
+      border-color: $nandor;
+      color: white;
+    }
+  }
+}
+
+.application-state {
+  font-size: toRem(14);
+  line-height: 1;
+  color: $greenYellow;
 }
 
 .header-subtitle {

--- a/packages/fe/components/app-accordion.vue
+++ b/packages/fe/components/app-accordion.vue
@@ -40,10 +40,13 @@
               <div class="panel-right">
                 <div class="application-type p2" v-html="entry.type" />
                 <div :class="['application-progress', entry.application_state]">
-                  <span
+                  <div
                     v-for="(value, key) in stateMap"
                     :key="`application-progress-state-${key}`"
-                    :class="['step', key, { highlight: key === entry.application_state }]" />
+                    :data-tooltip="value"
+                    :class="['step', key, { highlight: key === entry.application_state }]">
+                    <span class="circle" />
+                  </div>
                 </div>
                 <div class="application-state">
                   {{ stateMap[entry.application_state] }}
@@ -286,43 +289,62 @@ export default {
   align-items: center;
   margin: 0.5rem 0;
   .step {
-    @include applicationProgressStepHighlighted;
     display: flex;
-    flex-direction: column;
-    justify-content: center;
-    align-items: center;
     position: relative;
     width: 1rem;
     height: 1rem;
     border-radius: 50%;
-    border: 1px solid;
+    background-color: $aztec;
+    border: 1px solid $greenYellow;
+    cursor: help;
     transition: 150ms ease-in;
     &:not(:first-child) {
       margin-left: calc(#{toRem(19)} + #{toRem(3 * 2)});
-      &:before {
-        display: block;
-        content: '';
-        position: absolute;
-        top: toRem(5);
-        right: calc(100% + #{toRem(4)});
-        width: toRem(19);
-        height: toRem(3);
-        border-radius: toRem(3);
-        background-color: $nandor;
+      .circle {
+        &:before {
+          display: block;
+          content: '';
+          position: absolute;
+          top: toRem(5);
+          right: calc(100% + #{toRem(4)});
+          width: toRem(19);
+          height: toRem(3);
+          border-radius: toRem(3);
+          background-color: $nandor;
+        }
       }
     }
-    &.noRelevantLabels:after { content: '-'; }
-    &.reviewing:after { content: '1'; }
-    &.validated:after { content: '2'; }
-    &.completed:after { content: '3'; }
-    &:after {
-      font-size: toRem(9);
-      line-height: 1;
-    }
+    &.noRelevantLabels .circle:after { content: '-'; }
+    &.reviewing .circle:after { content: '1'; }
+    &.validated .circle:after { content: '2'; }
+    &.completed .circle:after { content: '3'; }
     &.highlight ~ * {
-      background-color: $aztec;
       border-color: $nandor;
       color: white;
+    }
+    &.highlight {
+      @include applicationProgressStepHighlighted;
+    }
+    &[data-tooltip] {
+      &:after {
+        color: white;
+        border-radius: toRem(6);
+      }
+    }
+    .circle {
+      display: flex;
+      flex-direction: column;
+      justify-content: center;
+      align-items: center;
+      position: absolute;
+      top: 0;
+      left: 0;
+      width: 100%;
+      height: 100%;
+      &:after {
+        font-size: toRem(9);
+        line-height: 1;
+      }
     }
   }
 }


### PR DESCRIPTION
The 4 applications states:

- Not Started
- In Review
- Validated
- Completed

are now visualized in the application history page accordion:

<img width="1366" alt="Screenshot 2023-07-26 at 8 05 42 PM" src="https://github.com/data-preservation-programs/filplus.storage/assets/11708190/d7c11666-2262-4b90-86f2-a2f8f86ebaaa">